### PR TITLE
feat: support configurable local trace_processor_shell path

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,41 @@ args = ["perfetto-mcp"]
 
 </details>
 
+### Optional: Use a Local `trace_processor_shell` Binary
+
+If your network environment blocks downloads, set
+`PERFETTO_MCP_TRACE_PROCESSOR_BIN_PATH` to an absolute path of a local
+`trace_processor_shell` binary.
+
+When this env var is set, `perfetto-mcp` uses that binary directly.
+When it is not set, default `perfetto` Python behavior is unchanged.
+
+Example (`mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "perfetto-mcp": {
+      "command": "uvx",
+      "args": ["perfetto-mcp"],
+      "env": {
+        "PERFETTO_MCP_TRACE_PROCESSOR_BIN_PATH": "D:/tools/perfetto/trace_processor_shell.exe"
+      }
+    }
+  }
+}
+```
+
+Example (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.perfetto-mcp]
+command = "uvx"
+args = ["perfetto-mcp"]
+[mcp_servers.perfetto-mcp.env]
+PERFETTO_MCP_TRACE_PROCESSOR_BIN_PATH = "D:/tools/perfetto/trace_processor_shell.exe"
+```
+
 ### Local Install (development server)
 
 ```bash

--- a/src/perfetto_mcp/connection_manager.py
+++ b/src/perfetto_mcp/connection_manager.py
@@ -1,11 +1,15 @@
 """Connection manager for persistent TraceProcessor connections."""
 
-import threading
 import logging
+import os
+import threading
 from typing import Optional
-from perfetto.trace_processor import TraceProcessor
+
+from perfetto.trace_processor import TraceProcessor, TraceProcessorConfig
 
 logger = logging.getLogger(__name__)
+
+TRACE_PROCESSOR_BIN_PATH_ENV = "PERFETTO_MCP_TRACE_PROCESSOR_BIN_PATH"
 
 
 class ConnectionManager:
@@ -15,6 +19,17 @@ class ConnectionManager:
         self._current_trace_path: Optional[str] = None
         self._current_connection: Optional[TraceProcessor] = None
         self._lock = threading.Lock()  # Thread safety
+        self._trace_processor_bin_path = self._read_trace_processor_bin_path()
+
+    def _read_trace_processor_bin_path(self) -> Optional[str]:
+        """Read optional trace processor binary path from environment."""
+        raw_bin_path = os.getenv(TRACE_PROCESSOR_BIN_PATH_ENV)
+        if raw_bin_path is None:
+            return None
+
+        # Normalize common quoted env var forms and ignore empty values.
+        normalized = raw_bin_path.strip().strip('"').strip("'")
+        return normalized if normalized else None
         
     def get_connection(self, trace_path: str) -> TraceProcessor:
         """Get or create connection for trace_path with automatic reconnection.
@@ -63,7 +78,10 @@ class ConnectionManager:
             ConnectionError: If connection fails
         """
         try:
-            tp = TraceProcessor(trace=trace_path)
+            tp = TraceProcessor(
+                trace=trace_path,
+                config=TraceProcessorConfig(bin_path=self._trace_processor_bin_path),
+            )
             logger.info(f"Successfully connected to trace: {trace_path}")
             return tp
         except FileNotFoundError as e:
@@ -74,6 +92,11 @@ class ConnectionManager:
             )
         except Exception as e:
             logger.error(f"Failed to connect to trace: {trace_path}, error: {e}")
+            if self._trace_processor_bin_path:
+                raise ConnectionError(
+                    "Could not connect to trace processor with configured "
+                    f"{TRACE_PROCESSOR_BIN_PATH_ENV}={self._trace_processor_bin_path}: {e}"
+                )
             raise ConnectionError(f"Could not connect to trace processor: {e}")
     
     def _is_connection_healthy(self) -> bool:

--- a/src/perfetto_mcp/connection_manager.py
+++ b/src/perfetto_mcp/connection_manager.py
@@ -94,8 +94,8 @@ class ConnectionManager:
                 raise ConnectionError(
                     "Could not connect to trace processor with configured "
                     f"{TRACE_PROCESSOR_BIN_PATH_ENV}={self._trace_processor_bin_path}: {e}"
-                )
-            raise ConnectionError(f"Could not connect to trace processor: {e}")
+                ) from e
+            raise ConnectionError(f"Could not connect to trace processor: {e}") from e
     
     def _reconnect(self, trace_path: str) -> TraceProcessor:
         """Reconnect to trace file after connection failure.


### PR DESCRIPTION
## Purpose
Avoid startup failures in restricted/offline networks by letting users provide a local `trace_processor_shell` binary instead of relying on perfetto's auto-download path.

## What Changed
- Added support for env var `PERFETTO_MCP_TRACE_PROCESSOR_BIN_PATH` in `ConnectionManager`.
- `TraceProcessor` is now initialized with:
  - `TraceProcessorConfig(bin_path=<env value>)` when configured.
  - `TraceProcessorConfig(bin_path=None)` when not configured (preserves default perfetto behavior).
- Improved connection error message when a configured local binary path fails.
- Updated README with explicit setup examples for Cursor/Codex config using local binary path.

## Why This Optimization
- Keeps existing behavior unchanged for current users.
- Enables "out-of-the-box" usage in environments where downloading `trace_processor` is unstable or blocked.
- Reduces troubleshooting time by making binary source configurable and failures clearer.

## Validation
- Local tests passed:
  - `PYTHONPATH=src python -m unittest discover -s tests -v`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support configuring a local trace_processor_shell binary via an environment variable.

* **Improvements**
  * Clearer, more informative error messages when connecting to a configured local binary fails.

* **Documentation**
  * New guide describing how to configure and use a local trace_processor_shell with example configurations.
  * Minor README formatting fix (ensured trailing newline).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->